### PR TITLE
Fix / add support for non-GNU Windows targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "in-container"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 authors = ["Pit Kleyersburg <pitkley@googlemail.com>"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "3.1.18"
 features = ["cargo", "derive"]
 optional = true
 
-[target.x86_64-pc-windows-gnu.dependencies]
+[target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"
 windows-service = "0.4.0"
 


### PR DESCRIPTION
The existing (v1.1.0) dependencies specify `winreg` & `windows-service` dependencies as only required for target `x86_64-pc-windows-gnu`.

On other Windows targets, such as the default `x86_64-pc-windows-msvc` target, these dependencies can therefore not be found.

The attached changes to `Cargo.toml` change these dependencies to be included for all Windows targets.